### PR TITLE
flac files bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rendertune",
   "productName": "RenderTune",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "combine audio and image files to create video files",
   "main": "main.js",
   "scripts": {

--- a/src/js/newindex.js
+++ b/src/js/newindex.js
@@ -1066,17 +1066,19 @@ async function render(renderOptions, debugConcatAudioCmd=null, debugRenderVideoC
     if (renderOptions.concatAudio) {
       let concatAudioFilepath = renderOptions.concatAudioFilepath;
       //add inputs
-      let inputs = '';
+      cmdArr.push('-y')
+      let filterMapStr='';
       for (var i = 0; i < selectedRows.length; i++) {
         cmdArr.push('-i')
-        cmdArr.push(`${selectedRows[i].audioFilepath}`)
-        inputs = `${inputs}-i "${selectedRows[i].audioFilepath}" `;
+        cmdArr.push(`${selectedRows[i].audioFilepath}`);
+        filterMapStr=`${filterMapStr}[${i}:a]`;
       }
 
       //add concat options
-      cmdArr.push("-y");
       cmdArr.push("-filter_complex")
-      cmdArr.push(`concat=n=${i}:v=0:a=1`)
+      cmdArr.push(`${filterMapStr}concat=n=${i}:v=0:a=1[a]`)
+      cmdArr.push(`-map`)
+      cmdArr.push(`[a]`)
       //add audio codec and quality 
       cmdArr.push("-c:a")
       cmdArr.push("libmp3lame")


### PR DESCRIPTION
new mp3 concat filter code tells ffmpeg to only concatenate audio, without this new code there are some files with corrupted metadata such as album art that cause ffmpeg to fail.